### PR TITLE
Ensure required paths are available when post script is executed.

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export PATH="$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 chain_exists() {
     [ $# -lt 1 -o $# -gt 2 ] && {
         echo "Usage: chain_exists <chain_name> [table]" >&2


### PR DESCRIPTION
I observed when csf is updated via cron [1] that the rules csfpost.sh should generate are not present, I suspect the path to the binaries invoked are not available.

[1] cat /etc/cron.d/csf_update
SHELL=/bin/sh
27 4 \* \* \* root /usr/sbin/csf -u
