### PR TITLE
Ensure dockers IP bindings are maintained for ip:port forwarding.

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -53,7 +53,12 @@ if [ `echo ${containers} | wc -c` -gt "1" ] ; then
                                 iptables -A DOCKER -d ${ipaddr}/32 ! -i ${DOCKER_INT} -o ${DOCKER_INT} -p ${dst_proto} -m ${dst_proto} --dport ${dst_port} -j ACCEPT
 
                                 iptables -t nat -A POSTROUTING -s ${ipaddr}/32 -d ${ipaddr}/32 -p ${dst_proto} -m ${dst_proto} --dport ${dst_port} -j MASQUERADE
-                                iptables -t nat -A DOCKER ! -i ${DOCKER_INT} -p ${dst_proto} -m ${dst_proto} --dport ${src_port} -j DNAT --to-destination ${ipaddr}:${dst_port}
+
+                                if [ $src_ip = "0.0.0.0" ] ; then
+                                        iptables -t nat -A DOCKER ! -i ${DOCKER_INT} -p ${dst_proto} -m ${dst_proto} --dport ${src_port} -j DNAT --to-destination ${ipaddr}:${dst_port}
+                                else
+                                        iptables -t nat -A DOCKER -d ${src_ip}/32 ! -i ${DOCKER_INT} -p ${dst_proto} -m ${dst_proto} --dport ${src_port} -j DNAT --to-destination ${ipaddr}:${dst_port}
+                                fi
                         done
                 fi
         done


### PR DESCRIPTION
When exposing a port only to a particular IP address with `-p 127.0.0.1:3005:3000` after a csf restart previously this would expose port 3005 to the world. With this change, ports that aren't exposed to 0.0.0.0 are limited.
